### PR TITLE
add output for broker IDs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.77.0
+  rev: v1.77.1
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "mq" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.60.0 |
 
 ## Modules
 
@@ -80,6 +80,7 @@ No modules.
 |------|-------------|
 | <a name="output_broker_arn"></a> [broker\_arn](#output\_broker\_arn) | AmazonMQ broker ARN. |
 | <a name="output_broker_id"></a> [broker\_id](#output\_broker\_id) | AmazonMQ broker ID. |
+| <a name="output_broker_instances"></a> [broker\_instances](#output\_broker\_instances) | AmazonMQ broker instances details. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "broker_arn" {
   description = "AmazonMQ broker ARN."
 }
 
-output "broker_ips" {
-  value       = aws_mq_broker.main.instances.0.ip_address
-  description = "AmazonMQ broker ARN."
+output "broker_instances" {
+  value       = aws_mq_broker.main.instances
+  description = "AmazonMQ broker instances details."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "broker_arn" {
   value       = aws_mq_broker.main.arn
   description = "AmazonMQ broker ARN."
 }
+
+output "broker_ips" {
+  value       = aws_mq_broker.main.instances.0.ip_address
+  description = "AmazonMQ broker ARN."
+}


### PR DESCRIPTION
Adding output for broker IPs, Terraform docs seem to allude to these outputs being relavent for both active and standby broker instances so not sure if a loop is needed or not in this case....

<img width="708" alt="image" src="https://user-images.githubusercontent.com/42376582/228206128-64de01c4-6096-47eb-aaa8-ea6ac717be2f.png">
