### PR TITLE
Subnet IDs are optional for public brokers

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,4 @@
 data "aws_subnet" "main" {
+  count = length(var.subnet_ids) > 0 ? 1 : 0
   id = var.subnet_ids[0]
 }

--- a/lb.tf
+++ b/lb.tf
@@ -23,7 +23,7 @@ resource "aws_lb_target_group" "main" {
   port        = var.nlb_tg_port
   protocol    = var.nlb_tg_protocol
   target_type = "ip"
-  vpc_id      = data.aws_subnet.main.vpc_id
+  vpc_id      = data.aws_subnet.main[0].vpc_id
 
   health_check {
     enabled           = true

--- a/sg.tf
+++ b/sg.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "main" {
 
   name        = var.security_group_name
   description = var.security_group_description
-  vpc_id      = data.aws_subnet.main.vpc_id
+  vpc_id      = data.aws_subnet.main[0].vpc_id
 
   revoke_rules_on_delete = var.revoke_rules_on_delete
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ variable "broker_name" {
 variable "subnet_ids" {
   type        = list(string)
   description = "List of VPC subnet IDs"
+  default     = []
 }
 
 variable "security_groups" {


### PR DESCRIPTION
Amazon MQ for RabbitMQ public brokers do not always have the subnet IDs populated when calling `describe-broker`, and it is optional for public brokers in `create-broker`. This is preventing the import of some existing brokers. I've made the subnet IDs optional (default to `[]`) and adjusted the resources and data blocks accordingly.